### PR TITLE
fix: navigation arrows for agenda table on mobile viewport

### DIFF
--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -111,8 +111,10 @@ function TrackTable({
   return (
     <div
       className={`shrink-0 w-full transition-all duration-300 ${
-        isActive ? "opacity-100" : "opacity-0 absolute"
-      }`}
+  isActive
+    ? "opacity-100 relative pointer-events-auto"
+    : "opacity-0 absolute pointer-events-none"
+}`}
     >
       <div className="bg-white rounded-xl shadow-lg overflow-hidden border border-gray-300">
         <div className={`${track.headerBg} px-6 py-4 flex items-center gap-3`}>


### PR DESCRIPTION
## why mobile arrows weren’t working
Inactive agenda tables were rendered as absolutely positioned invisible layers that were still capturing pointer events on mobile. Disabling pointer events for inactive tracks fixed the issue without changing layout or logic.

<img width="320" height="690" alt="Screenshot 2026-01-29 at 11 37 41 AM" src="https://github.com/user-attachments/assets/76208b73-9ba0-46ec-8702-18315b9770e9" />
