### PR TITLE
fix: update Register CTA to point to Beta tickets across hero and modal

### DIFF
--- a/src/components/RegistrationModal.tsx
+++ b/src/components/RegistrationModal.tsx
@@ -99,7 +99,7 @@ export default function RegistrationModal({
         {/* Content */}
         <div className="overflow-y-auto h-[calc(100vh-64px)] md:max-h-[calc(90vh-64px)]">
           <iframe
-            src="https://konfhub.com/widget/kcd-delhi-2026?desc=true&secondaryBg=fffff8&ticketBg=fffff8&borderCl=fffff8&bg=ffffff&fontColor=1e1f24&ticketCl=1e1f24&btnColor=6e3d00&fontFamily=Figtree&borderRadius=10&widget_type=standard&tickets=67969&ticketId=67969%7C1"
+            src="https://konfhub.com/widget/kcd-delhi-2026?desc=true&secondaryBg=fffff8&ticketBg=fffff8&borderCl=fffff8&bg=ffffff&fontColor=1e1f24&ticketCl=1e1f24&btnColor=6e3d00&fontFamily=Figtree&borderRadius=10&widget_type=standard&tickets=70668&ticketId=70668%7C1"
             id="konfhub-widget"
             title="Register for KCD Delhi 2026"
             width="100%"


### PR DESCRIPTION
This PR updates the Register CTA flow to ensure users are always directed to the active Beta ticket instead of Alpha tickets.

<img width="1440" height="780" alt="Screenshot 2026-01-29 at 1 22 09 PM" src="https://github.com/user-attachments/assets/b8fecf17-4e6d-472a-9f2a-04fee8c1b9de" />
